### PR TITLE
make USER_ROLES var a dict with email as a property for each user

### DIFF
--- a/py/send_notifications.py
+++ b/py/send_notifications.py
@@ -238,7 +238,8 @@ def send_notifications(param_file, count_date):
         '''
 
     # For each user, check if any of the fields they're responsible for have yet to be verified
-    for user, roles in user_roles.items():
+    for user, user_info in user_roles.items():
+        roles = user_info['roles']
         unverified_fields = data.loc[data.role.isin(roles), 'dena_label']
         if len(unverified_fields):
             # Compose the email
@@ -249,7 +250,7 @@ def send_notifications(param_file, count_date):
                 img_html=img_html
             )
 
-            recipient = f'{user}@nps.gov'
+            recipient = user_info['email']
 
             try:
                 send_email(message, subject, params['mail_sender'], [recipient], server, message_body_type='html')


### PR DESCRIPTION
Originally, all users' UPNs were valid email addresses, so to send them an email, I only needed their username. IT policy changed and alternate email addresses are no longer created from UPNs. Now the `USER_ROLES` var in `vistats-entry-config.php` is a JSON string with each root element value as a dictionary including an explicit email address for each one.