### PR TITLE
use new USER_ROLES structure

### DIFF
--- a/web/vistats-entry.html
+++ b/web/vistats-entry.html
@@ -108,9 +108,14 @@
 								username = usernameString.trim().toLowerCase();
 								$('#username').text(username);
 								getUserRoles()
-									.then(
-										(jsonString) => {
-										USER_ROLES = $.parseJSON(jsonString);
+									.then(jsonString => {
+										USER_ROLES = Object.fromEntries(
+											Object.entries(
+												$.parseJSON(jsonString)
+											).map(
+												([username, info]) => [username, info.roles]
+											)
+										)
 										configureForm().then(resizeColumns);
 
 									})


### PR DESCRIPTION
each entry of `USER_ROLES` in `vistats-entry-config.php` is a dictionary with `email` and `roles` as properties. This change parses the JSON correctly to still assign `USER_ROLES` in the JS to be in the format `{username: [roles]}`